### PR TITLE
docs: update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Certifique-se de ter o **Docker Desktop** (ou Docker Engine e Docker Compose) in
 1.  **Clone o Repositório:**
 
     ```bash
-    git clone git@github.com:marcelowillyan/car-rental-search.git
+    git clone https://github.com/marcelowillyan/car-rental-search.git
     cd car-rental-search
     ```
 


### PR DESCRIPTION
This pull request updates the git clone command in the README.md file to reflect the correct repository URL. This ensures that users can properly clone the project using the most accurate and up-to-date link.

Changes made:
- Replaced the placeholder or outdated GitHub URL in the git clone section
- Confirmed that the new link points directly to this repository